### PR TITLE
Update tag-input-autocomplete.component.ts

### DIFF
--- a/lib/components/tag-input-autocomplete/tag-input-autocomplete.component.ts
+++ b/lib/components/tag-input-autocomplete/tag-input-autocomplete.component.ts
@@ -143,18 +143,18 @@ export class TagInputAutocompleteComponent implements OnChanges, OnDestroy, OnIn
   handleUpArrow() {
     if (this.selectedItemIndex === null) {
       this.goToBottom(this.itemsCount);
-      return false;
+    } else {
+      this.goToPrevious();
     }
-    this.goToPrevious();
   }
 
   handleDownArrow() {
     // Initialize to zero if first time results are shown
     if (this.selectedItemIndex === null) {
-        this.goToTop();
-        return false;
+      this.goToTop();
+    } else {
+      this.goToNext();
     }
-    this.goToNext();
   }
 
   selectItem(itemIndex?: number): void {


### PR DESCRIPTION
The functions handleUpArrow() and handleDownArrow() did return a false in some cases for some reasons. 
If the selectedItemIndex is not null, nothing gets returned. This is against good code style, throws tslint error and crashes the AOT build.